### PR TITLE
Include css folder in the package distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "index.js",
     "index.es5.js",
+    "css",
     "docs",
     "dist",
     "src",


### PR DESCRIPTION
If we include the src, then css is also source and should be included.
Better supports installing from git repo where dist folder is not present.